### PR TITLE
Fix local dev defaults and align setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ FLASK_APP=app.py
 # If not set, the app falls back to SQLite (cvtailro_dev.db) for local dev.
 DATABASE_URL=postgresql://cvtailro:cvtailro@localhost:5432/cvtailro
 
+# Required for docker-compose local Postgres startup.
+POSTGRES_PASSWORD=change-me
+
 # --- Google OAuth 2.0 -------------------------------------------------------
 # Required for user authentication. Create credentials at:
 #   https://console.cloud.google.com/apis/credentials

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ pip install -r requirements.txt
 cp .env.example .env
 # Edit .env with GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, OPENROUTER_API_KEY, etc.
 
+export FLASK_ENV=development
 python app.py   # or: python wsgi.py
 # Open http://localhost:5050
 ```

--- a/SETUP.md
+++ b/SETUP.md
@@ -301,7 +301,7 @@ When no `DATABASE_URL` is set, the application falls back to a local SQLite data
 
 #### Prerequisites
 
-- Python 3.13+
+- Python 3.11+ (3.13 recommended; CI and Docker run 3.13)
 - System libraries for WeasyPrint (cairo, pango, gdk-pixbuf). On macOS:
 
 ```bash

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ import os
 
 from app import create_app
 
-app = create_app()
+app = create_app(os.environ.get("FLASK_ENV", "development"))
 
 if __name__ == "__main__":
     import logging


### PR DESCRIPTION
## Summary
- default local app.py startup to `FLASK_ENV=development`
- document `export FLASK_ENV=development` in README quickstart
- align SETUP Python requirement wording (3.11+; 3.13 recommended)
- add `POSTGRES_PASSWORD` to `.env.example` for docker-compose users

## Why
These changes remove local onboarding friction and resolve config/documentation mismatches found in audit.

## Validation
- Verified edits apply cleanly
- Confirmed branch push to fork and PR readiness