### PR TITLE
Security hardening: fix in-memory IDOR and lock down dev-login

### DIFF
--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -210,9 +210,13 @@ def progress_stream(job_id: str):
 def get_result(job_id: str):
     with jobs_lock:
         job = jobs.get(job_id)
-        if job is not None and current_user.is_authenticated:
-            if job.get("user_id") and job["user_id"] != current_user.id:
-                return jsonify({"error": "Job not found"}), 404
+        if job is not None:
+            job_user_id = job.get("user_id")
+            if job_user_id is not None:
+                if not current_user.is_authenticated:
+                    return jsonify({"error": "Job not found"}), 404
+                if job_user_id != current_user.id:
+                    return jsonify({"error": "Job not found"}), 404
 
     if job is not None:
         if job["status"] == "running":

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -27,6 +27,11 @@ def _client_ip() -> str:
     return request.headers.get("X-Forwarded-For", "").split(",")[0].strip() or request.remote_addr or "unknown"
 
 
+def _is_local_request() -> bool:
+    ip = _client_ip()
+    return ip in {"127.0.0.1", "::1", "localhost"}
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 #  Google OAuth
 # ═══════════════════════════════════════════════════════════════════════════
@@ -265,7 +270,12 @@ def me():
 def dev_login():
     from flask import current_app
 
-    if not current_app.debug or os.environ.get("DEV_AUTH_BYPASS") != "1":
+    if (
+        not current_app.debug
+        or os.environ.get("FLASK_ENV") == "production"
+        or os.environ.get("DEV_AUTH_BYPASS") != "1"
+        or not _is_local_request()
+    ):
         return redirect("/")
 
     email = os.environ.get("DEV_AUTH_EMAIL", "dev@example.com").lower()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -149,6 +149,31 @@ def test_heartbeat(client):
 
 
 @pytest.mark.integration
+def test_dev_login_blocked_for_non_localhost(client, monkeypatch):
+    """Dev login must reject non-local requests even with bypass enabled."""
+    monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+    monkeypatch.setenv("FLASK_ENV", "development")
+
+    resp = client.get("/auth/dev-login", headers={"X-Forwarded-For": "203.0.113.9"})
+    assert resp.status_code == 302
+
+
+@pytest.mark.integration
+def test_dev_login_allows_localhost_with_explicit_bypass(client, monkeypatch):
+    """Dev login should only work for local requests with explicit bypass."""
+    monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+    monkeypatch.setenv("FLASK_ENV", "development")
+    monkeypatch.setenv("DEV_AUTH_EMAIL", "localdev@example.com")
+
+    resp = client.get("/auth/dev-login", headers={"X-Forwarded-For": "127.0.0.1"})
+    assert resp.status_code == 302
+
+    me = client.get("/auth/me").get_json()
+    assert me["authenticated"] is True
+    assert me["email"] == "localdev@example.com"
+
+
+@pytest.mark.integration
 def test_revoke_other_sessions(client):
     """User can revoke all other sessions."""
     user = _create_google_user()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -158,11 +158,35 @@ class TestIDORResult:
     """IDOR: Anonymous users must not access authenticated users' job results."""
 
     def test_anonymous_cannot_access_user_job_result(self, client, user_job):
-        """Anonymous user must not get another user's job result (IDOR)."""
+        """Anonymous user must not get another user's persisted job result (IDOR)."""
         resp = client.get(f"/api/result/{user_job.id}")
         assert resp.status_code == 404
         data = resp.get_json()
         assert "ats_resume_md" not in (data or {}).get("result", {})
+
+    def test_anonymous_cannot_access_user_job_result_in_memory(self, client, user_job, flask_app):
+        """Anonymous user must not get another user's in-memory running/completed job result."""
+        with flask_app.app_context():
+            from app.services.pipeline import jobs, jobs_lock
+
+            with jobs_lock:
+                jobs[user_job.id] = {
+                    "status": "complete",
+                    "user_id": user_job.user_id,
+                    "result": {"ats_resume_md": "# Secret"},
+                    "error": None,
+                    "queue": None,
+                    "output_dir": "/tmp",
+                }
+        try:
+            resp = client.get(f"/api/result/{user_job.id}")
+            assert resp.status_code == 404
+        finally:
+            with flask_app.app_context():
+                from app.services.pipeline import jobs, jobs_lock
+
+                with jobs_lock:
+                    jobs.pop(user_job.id, None)
 
     def test_anonymous_can_access_anonymous_job_result(self, client, anonymous_job):
         """Anonymous user can access their own anonymous job result."""


### PR DESCRIPTION
## Security audit scope (phase 1)
Focused review on auth/session boundaries, IDOR, and debug auth controls in API/auth routes.

## Findings fixed
1. **IDOR in in-memory job results**
   - `GET /api/result/<job_id>` could expose in-memory results for authenticated users' jobs to anonymous users while a job existed in memory.
   - Added ownership checks for both authenticated and anonymous callers before returning in-memory results.

2. **Dev auth hardening**
   - `/auth/dev-login` now requires all of:
     - debug mode enabled
     - non-production environment
     - explicit `DEV_AUTH_BYPASS=1`
     - local request origin (`127.0.0.1` / `::1`)
   - This reduces risk of accidental exposure if debug toggles are misconfigured.

## Test coverage added
- `test_anonymous_cannot_access_user_job_result_in_memory`
- `test_dev_login_blocked_for_non_localhost`
- `test_dev_login_allows_localhost_with_explicit_bypass`

## Validation run
```bash
FLASK_ENV=testing FLASK_SECRET_KEY=ci-test-secret pytest -q \
  tests/test_security.py::TestIDORResult \
  tests/test_auth.py::test_dev_login_blocked_for_non_localhost \
  tests/test_auth.py::test_dev_login_allows_localhost_with_explicit_bypass
```
Passed locally.
