### PR TITLE
SEO: add robots.txt and sitemap.xml endpoints

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,6 +1,6 @@
-"""Main routes — index page, health check, status, and model listing."""
+"""Main routes — index page, health check, status, model listing, and SEO assets."""
 
-from flask import Blueprint, jsonify, render_template
+from flask import Blueprint, Response, current_app, jsonify, render_template
 from sqlalchemy import text
 
 from app.extensions import db
@@ -35,6 +35,44 @@ def pricing():
 @main_bp.route("/contact")
 def contact():
     return render_template("contact.html")
+
+
+@main_bp.route("/robots.txt")
+def robots_txt():
+    base_url = current_app.config.get("BLOG_BASE_URL", "https://cvtailro-production.up.railway.app").rstrip("/")
+    body = "\n".join(
+        [
+            "User-agent: *",
+            "Allow: /",
+            f"Sitemap: {base_url}/sitemap.xml",
+            "",
+        ]
+    )
+    return Response(body, mimetype="text/plain")
+
+
+@main_bp.route("/sitemap.xml")
+def sitemap_xml():
+    base_url = current_app.config.get("BLOG_BASE_URL", "https://cvtailro-production.up.railway.app").rstrip("/")
+    urls = [
+        f"{base_url}/",
+        f"{base_url}/pricing",
+        f"{base_url}/blog/",
+        f"{base_url}/privacy",
+        f"{base_url}/terms",
+        f"{base_url}/contact",
+    ]
+    for post in list_posts():
+        urls.append(f"{base_url}/blog/{post.slug}")
+
+    items = "\n".join(f"  <url><loc>{u}</loc></url>" for u in urls)
+    xml = (
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n"
+        f"{items}\n"
+        "</urlset>\n"
+    )
+    return Response(xml, mimetype="application/xml")
 
 
 @main_bp.route("/api/health")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -44,3 +44,21 @@ def test_admin_page(client):
     resp = client.get("/admin")
     assert resp.status_code == 200
     assert b"CVtailro Admin" in resp.data
+
+
+@pytest.mark.integration
+def test_robots_txt(client):
+    resp = client.get("/robots.txt")
+    assert resp.status_code == 200
+    text = resp.get_data(as_text=True)
+    assert "User-agent:" in text
+    assert "Sitemap:" in text
+
+
+@pytest.mark.integration
+def test_sitemap_xml(client):
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 200
+    text = resp.get_data(as_text=True)
+    assert "<urlset" in text
+    assert "<loc>" in text


### PR DESCRIPTION
## Summary
Fixes #8 by adding production-ready SEO discovery endpoints:
- `GET /robots.txt`
- `GET /sitemap.xml`

## What changed
- Added `robots_txt()` and `sitemap_xml()` routes in `app/routes/main.py`
- Sitemap includes key static pages plus all blog post URLs from `list_posts()`
- Added integration tests:
  - `test_robots_txt`
  - `test_sitemap_xml`

## Verification
- `./.venv/bin/pytest -q tests/test_health.py tests/test_security.py`
- Result: 46 passed

## Risk
Low. Read-only endpoints, no auth/session behavior changes.
